### PR TITLE
install packages using remote download

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,7 +22,7 @@ platforms:
 suites:
   - name: chef-server
     run_list:
-      # - recipe[ntp]
+      - recipe[ntp]
       - recipe[test::hostsfile]
       - recipe[test::setup_ssh_keys]
       - recipe[test::chef-server]
@@ -34,21 +34,45 @@ suites:
         memory: 2048
         cpus: 2
     attributes:
+      chef-server:
+        package_url: 'https://packages.chef.io/stable/el/7/chef-server-core-12.8.0-1.el7.x86_64.rpm'
+        package_source: '/tmp/chef-server-core-12.8.0-1.el7.x86_64.rpm'
+        config: |
+          api_fqdn "chef.services.com"
+          oc_id['applications'] = {
+            "supermarket"=>{"redirect_uri"=>"https://supermarket.services.com/auth/chef_oauth2/callback"}
+          }
+      push-jobs-server:
+        package_url: 'https://packages.chef.io/stable/el/7/opscode-push-jobs-server-2.1.0-1.el7.x86_64.rpm'
+        package_source: '/tmp/opscode-push-jobs-server-2.1.0-1.el7.x86_64.rpm'
+      manage:
+        package_url: 'https://packages.chef.io/stable/el/7/chef-manage-2.4.3-1.el7.x86_64.rpm'
+        package_source: '/tmp/chef-manage-2.4.3-1.el7.x86_64.rpm'
 
   - name: automate
     run_list:
-      # - recipe[ntp]
+      - recipe[ntp]
       - recipe[test::hostsfile]
       - recipe[test::delivery_keys]
       - recipe[test::delivery]
-      - recipe[test::create_enterprise]
       - recipe[test::delivery_node]
     attributes:
       delivery:
-        fqdn: 'automate.services.com'
-        chef_server: https://chef.services.com/organizations/delivery
-        insights:
-          enable: true
+        package_url: 'https://packages.chef.io/stable/el/7/delivery-0.5.125-1.el7.x86_64.rpm'
+        package_source: '/tmp/delivery-0.5.125-1.el7.x86_64.rpm'
+        config: |
+          delivery_fqdn "automate.services.com"
+
+          delivery['chef_username']    = "delivery"
+          delivery['chef_private_key'] = "/etc/delivery/delivery.pem"
+          delivery['chef_server']      = "https://chef.services.com/organizations/delivery"
+
+          delivery['default_search']   = "((recipes:delivery_build OR tags:delivery-build-node OR recipes:delivery_build\\\\\\\\:\\\\\\\\:default) AND chef_environment:_default)"
+
+          insights['enable'] = true
+      chefdk:
+        package_url: 'https://packages.chef.io/stable/el/7/chefdk-0.17.17-1.el7.x86_64.rpm'
+        package_source: '/tmp/chefdk-0.17.17-1.el7.x86_64.rpm'
     driver:
       vm_hostname: automate.services.com
       network:
@@ -72,23 +96,23 @@ suites:
         memory: 1024
         cpus: 1
 
-  - name: supermarket
-    run_list:
-      - recipe[ntp]
-      - recipe[test::hostsfile]
-      - recipe[test::setup_ssh_keys]
-      - recipe[test::supermarket]
-    attributes:
-      supermarket_omnibus:
-        chef_server_url: 'https://chef.services.com'
-        chef_oauth2_verify_ssl: false
-    driver:
-      vm_hostname: supermarket.services.com
-      network:
-        - ['private_network', {ip: '33.33.33.13'}]
-      customize:
-        memory: 1024
-        cpus: 1
+  # - name: supermarket
+  #   run_list:
+  #     - recipe[ntp]
+  #     - recipe[test::hostsfile]
+  #     - recipe[test::setup_ssh_keys]
+  #     - recipe[test::supermarket]
+  #   attributes:
+  #     supermarket_omnibus:
+  #       chef_server_url: 'https://chef.services.com'
+  #       chef_oauth2_verify_ssl: false
+  #   driver:
+  #     vm_hostname: supermarket.services.com
+  #     network:
+  #       - ['private_network', {ip: '33.33.33.13'}]
+  #     customize:
+  #       memory: 1024
+  #       cpus: 1
 
   - name: compliance
     run_list:

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,7 +1,7 @@
 DEPENDENCIES
   chef-ingredient
     git: https://github.com/chef-cookbooks/chef-ingredient.git
-    revision: 0bd1ebd3d792489a59a3b1d25ef194a187ec51bd
+    revision: b18b627f0c1e4bf7558f868268ba9970cb98262b
   chef-server-ctl
     git: https://github.com/stephenlauck/chef-server-ctl.git
     revision: 55bfa054f9d5cda86f1a96b28b5ccaddbec7a69d
@@ -10,16 +10,16 @@ DEPENDENCIES
     metadata: true
   supermarket-omnibus-cookbook
     git: https://github.com/chef-cookbooks/supermarket-omnibus-cookbook.git
-    revision: 552ea1fed606422799db649b8e15424f606c795f
+    revision: 1bfedf348123e7b88d50684b2cf406b470834dc6
   test
     path: test/fixtures/cookbooks/test
 
 GRAPH
   apt (4.0.2)
     compat_resource (>= 12.10)
-  chef-ingredient (0.19.0)
+  chef-ingredient (0.20.0)
     compat_resource (>= 12.10.0)
-  chef-server (5.0.1)
+  chef-server (5.1.0)
     chef-ingredient (>= 0.18.0)
   chef-server-ctl (0.1.0)
     chef-server (>= 0.0.0)
@@ -27,14 +27,13 @@ GRAPH
     apt (>= 0.0.0)
     ntp (>= 0.0.0)
     yum (>= 0.0.0)
-  chef_handler (1.4.0)
-  compat_resource (12.14.0)
-  fancy_execute (1.0.1)
+  compat_resource (12.14.6)
+  fancy_execute (1.0.2)
   hostsfile (2.4.5)
-  ntp (2.0.2)
-    windows (>= 1.38.0)
-  supermarket-omnibus-cookbook (1.4.1)
-    chef-ingredient (>= 0.18.0)
+  ntp (3.1.0)
+  supermarket-omnibus-cookbook (2.0.0)
+    chef-ingredient (>= 0.19.0)
+    compat_resource (>= 12.14.3)
     fancy_execute (>= 0.0.0)
     hostsfile (>= 0.0.0)
   test (0.0.1)
@@ -42,6 +41,4 @@ GRAPH
     chef-server-ctl (>= 0.0.0)
     hostsfile (>= 0.0.0)
     supermarket-omnibus-cookbook (>= 0.0.0)
-  windows (1.44.3)
-    chef_handler (>= 0.0.0)
-  yum (3.12.0)
+  yum (3.13.0)

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,7 +1,7 @@
 DEPENDENCIES
   chef-ingredient
     git: https://github.com/chef-cookbooks/chef-ingredient.git
-    revision: 375df47818c7ce61dc71c033c2ff4d1cf2a6558c
+    revision: 0bd1ebd3d792489a59a3b1d25ef194a187ec51bd
   chef-server-ctl
     git: https://github.com/stephenlauck/chef-server-ctl.git
     revision: 55bfa054f9d5cda86f1a96b28b5ccaddbec7a69d
@@ -18,19 +18,20 @@ GRAPH
   apt (4.0.2)
     compat_resource (>= 12.10)
   chef-ingredient (0.19.0)
+    compat_resource (>= 12.10.0)
   chef-server (5.0.1)
     chef-ingredient (>= 0.18.0)
   chef-server-ctl (0.1.0)
     chef-server (>= 0.0.0)
-  chef-services (2.0.2)
+  chef-services (2.0.5)
     apt (>= 0.0.0)
     ntp (>= 0.0.0)
     yum (>= 0.0.0)
   chef_handler (1.4.0)
-  compat_resource (12.10.7)
+  compat_resource (12.14.0)
   fancy_execute (1.0.1)
   hostsfile (2.4.5)
-  ntp (2.0.0)
+  ntp (2.0.2)
     windows (>= 1.38.0)
   supermarket-omnibus-cookbook (1.4.1)
     chef-ingredient (>= 0.18.0)
@@ -43,4 +44,4 @@ GRAPH
     supermarket-omnibus-cookbook (>= 0.0.0)
   windows (1.44.3)
     chef_handler (>= 0.0.0)
-  yum (3.11.0)
+  yum (3.12.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,4 @@ version          '2.0.5'
 
 depends 'yum'
 depends 'apt'
+depends 'ntp'

--- a/test/fixtures/cookbooks/test/attributes/default.rb
+++ b/test/fixtures/cookbooks/test/attributes/default.rb
@@ -1,9 +1,32 @@
-default['delivery']['version'] = 'latest'
-default['delivery']['chef_server'] = 'https://chef.services.com/organizations/delivery'
+default['chef-server'] = {
+  'package_url' => nil,
+  'package_source' => nil,
+  'config' => ''
+}
 
-default['compliance']['version'] = 'latest'
-default['compliance']['package_source'] = nil
-default['compliance']['channel'] = :stable
-default['compliance']['accept_license'] = false
+default['manage'] = {
+  'package_url' => nil,
+  'package_source' => nil
+}
 
-default['chefdk']['bashrc'] = '/etc/bashrc'
+default['push-jobs-server'] = {
+  'package_url' => nil,
+  'package_source' => nil
+}
+
+default['delivery'] = {
+  'package_url' => nil,
+  'package_source' => nil,
+  'chef_server' => 'https://chef.services.com/organizations/delivery'
+}
+
+default['compliance'] = {
+  'package_url' => nil,
+  'package_source' => nil
+}
+
+default['chefdk'] = {
+  'package_url' => nil,
+  'package_source' => nil,
+  'bashrc' => '/etc/bashrc'
+}

--- a/test/fixtures/cookbooks/test/recipes/chef-server.rb
+++ b/test/fixtures/cookbooks/test/recipes/chef-server.rb
@@ -1,41 +1,22 @@
-chef_ingredient "chef-server" do
-  config <<-EOS
-api_fqdn "chef.services.com"
+%w( chef-server manage push-jobs-server ).each do |pkg|
 
-oc_id['applications'] = {
-  "supermarket"=>{"redirect_uri"=>"https://supermarket.services.com/auth/chef_oauth2/callback"}
-}
-EOS
-  action :upgrade
-  version :latest
-  accept_license true
-  package_source node['chef-server']['package_source']
-end
+  remote_file node[pkg]['package_source'] do
+    source node[pkg]['package_url']
+    only_if { node[pkg]['package_url'] }
+  end
 
-ingredient_config "chef-server" do
-  notifies :reconfigure, "chef_ingredient[chef-server]", :immediately
-end
-
-%w( manage ).each do |addon|
-  chef_ingredient addon do
+  chef_ingredient pkg do
+    config node[pkg]['config']
+    action :upgrade
     accept_license true
+    package_source node[pkg]['package_source']
   end
 
-  ingredient_config addon do
-    notifies :reconfigure, "chef_ingredient[#{addon}]", :immediately
+  ingredient_config pkg do
+    notifies :reconfigure, "chef_ingredient[#{pkg}]", :immediately
+    only_if { node[pkg]['config'] }
   end
-end
 
-# download and install push-jobs-server
-remote_file '/tmp/opscode-push-jobs-server-1.1.6-1.x86_64.rpm' do
-  source 'https://bintray.com/chef/stable/download_file?file_path=el%2F6%2Fopscode-push-jobs-server-1.1.6-1.x86_64.rpm'
-end
-
-chef_ingredient 'push-jobs-server' do
-  accept_license true
-  version '1.1.6-1'
-  package_source '/tmp/opscode-push-jobs-server-1.1.6-1.x86_64.rpm'
-  notifies :reconfigure, "chef_ingredient[push-jobs-server]"
 end
 
 chef_server_user 'delivery' do

--- a/test/fixtures/cookbooks/test/recipes/chef-server.rb
+++ b/test/fixtures/cookbooks/test/recipes/chef-server.rb
@@ -7,9 +7,9 @@
 
   chef_ingredient pkg do
     config node[pkg]['config']
+    package_source node[pkg]['package_source']
     action [:upgrade, :reconfigure]
     accept_license true
-    package_source node[pkg]['package_source']
   end
 
   ingredient_config pkg do

--- a/test/fixtures/cookbooks/test/recipes/chef-server.rb
+++ b/test/fixtures/cookbooks/test/recipes/chef-server.rb
@@ -7,7 +7,7 @@
 
   chef_ingredient pkg do
     config node[pkg]['config']
-    action :upgrade
+    action [:upgrade, :reconfigure]
     accept_license true
     package_source node[pkg]['package_source']
   end

--- a/test/fixtures/cookbooks/test/recipes/compliance.rb
+++ b/test/fixtures/cookbooks/test/recipes/compliance.rb
@@ -1,14 +1,5 @@
 chef_ingredient 'compliance' do
-	channel node['compliance']['channel'].to_sym
-	version node['compliance']['version']
 	package_source node['compliance']['package_source']
-	accept_license node['compliance']['accept_license'] unless node['compliance']['accept_license'].nil?
+	accept_license true
 	action [:upgrade, :reconfigure]
 end
-
-# execute 'chef-compliance-ctl user-create admin' do
-# 	command 'chef-compliance-ctl user-create admin "password" && touch /etc/chef-compliance/admin-user-created'
-# 	creates '/etc/chef-compliance/admin-user-created'
-# 	action :run
-# 	not_if do ::File.exists?('/etc/chef-compliance/admin-user-created') end
-# end

--- a/test/fixtures/cookbooks/test/recipes/delivery_keys.rb
+++ b/test/fixtures/cookbooks/test/recipes/delivery_keys.rb
@@ -13,6 +13,7 @@ cookbook_file '/etc/delivery/builder_key' do
   group 'root'
   mode '0600'
   source 'insecure_private_key'
+  sensitive true
 end
 
 cookbook_file '/etc/delivery/builder_key.pub' do

--- a/test/fixtures/cookbooks/test/recipes/delivery_node.rb
+++ b/test/fixtures/cookbooks/test/recipes/delivery_node.rb
@@ -19,15 +19,10 @@ end
 file '/etc/chef/dna.json' do
   content <<-EOF
 {
-    "delivery": {
-        "fqdn": "automate.services.com",
-        "chef_server": "https://chef.services.com/organizations/delivery"
-    },
     "run_list": [
         "recipe[test::hostsfile]",
         "recipe[test::delivery_keys]",
-        "recipe[test::delivery]",
-        "recipe[test::create_enterprise]"
+        "recipe[test::delivery]"
     ]
 }
   EOF

--- a/test/fixtures/cookbooks/test/recipes/setup_ssh_keys.rb
+++ b/test/fixtures/cookbooks/test/recipes/setup_ssh_keys.rb
@@ -13,6 +13,7 @@ cookbook_file '/root/.ssh/insecure_private_key' do
   group 'root'
   mode '0600'
   source 'insecure_private_key'
+  sensitive true
 end
 
 cookbook_file '/root/.ssh/authorized_keys' do


### PR DESCRIPTION
Add option to install chef packages via chef-ingredient, but download the correct packages via remote_file in order to get around package resolution for SLES.
