### PR TITLE
Enforced line endings for sh and license files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+*.sh text eol=lf
+*.license binary

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'you@example.com'
 license          'all_rights'
 description      'Installs/Configures chef-services'
 long_description 'Installs/Configures chef-services'
-version          '4.2.0'
+version          '4.2.1'
 
 depends 'fancy_execute'
 depends 'chef_stack'


### PR DESCRIPTION
Added .gitattributes file to root of repo to for unix line endings on sh files and binary on the license key. Taken from GitHub documentation - https://help.github.com/articles/dealing-with-line-endings/.

This solves the line ending issue identified by Windows users where installer.sh would fail during the kitchen converge.